### PR TITLE
fix: change multiprocessing start method to fork

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
+- `Matt Siegfried (Colorado School of Mines) <https://geophysics.mines.edu/project/siegfried-matthew/>`_
 - `Tyler Sutterley (University of Washington) <http://psc.apl.uw.edu/people/investigators/tyler-sutterley/>`_

--- a/doc/source/user_guide/nsidc_icesat2_sync.md
+++ b/doc/source/user_guide/nsidc_icesat2_sync.md
@@ -30,6 +30,7 @@ python nsidc_icesat2_sync.py --user <username> --directory <outgoing> \
 - `-R X`, `--retry X`: Connection retry attempts
 - `--log`: output log of files downloaded
 - `--list`: print files to be transferred, but do not execute transfer
+- `--checksum`: compare hashes to check if overwriting existing data
 - `-C`, `--clobber`: Overwrite existing data in transfer
 
 Also look into using the [NSIDC subsetting API](https://github.com/tsutterley/nsidc-subsetter)

--- a/icesat2_toolkit/utilities.py
+++ b/icesat2_toolkit/utilities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 utilities.py
-Written by Tyler Sutterley (03/2021)
+Written by Tyler Sutterley (07/2021)
 Download and management utilities for syncing time and auxiliary files
 
 PYTHON DEPENDENCIES:
@@ -9,6 +9,7 @@ PYTHON DEPENDENCIES:
         https://pypi.python.org/pypi/lxml
 
 UPDATE HISTORY:
+    Updated 07/2021: return Earthdata opener from build function
     Updated 03/2021: added sha1 option for retrieving file hashes
     Updated 01/2021: added username and password to ftp functions
         added ftp connection check
@@ -465,6 +466,7 @@ def build_opener(username, password, context=ssl.SSLContext(),
     #-- All calls to urllib2.urlopen will now use handler
     #-- Make sure not to include the protocol in with the URL, or
     #-- HTTPPasswordMgrWithDefaultRealm will be confused.
+    return opener
 
 #-- PURPOSE: check that entered NASA Earthdata credentials are valid
 def check_credentials():

--- a/scripts/convert_ICESat2_format.py
+++ b/scripts/convert_ICESat2_format.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 convert_ICESat2_format.py
-Written by Tyler Sutterley (10/2020)
+Written by Tyler Sutterley (07/2021)
 
 Converts ICESat-2 HDF5 datafiles to zarr or rechunked HDF5 datafiles
 
@@ -56,6 +56,7 @@ PYTHON DEPENDENCIES:
         https://pandas.pydata.org/
 
 UPDATE HISTORY:
+    Updated 07/2021: set context for multiprocessing to fork child processes
     Updated 01/2021: generalized to output either zarr or rechunked HDF5
     Updated 10/2020: using argparse to set parameters. added verbose keyword
         added chunks keyword to rechunk output zarr files
@@ -126,8 +127,10 @@ def convert_ICESat2_format(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES,
             #-- print the output string
             print(output) if VERBOSE else None
     else:
+        #-- set multiprocessing start method
+        ctx = mp.get_context("fork")
         #-- convert in parallel with multiprocessing Pool
-        pool = mp.Pool(processes=PROCESSES)
+        pool = ctx.Pool(processes=PROCESSES)
         #-- convert each ICESat-2 data file
         output = []
         for hdf5_file in hdf5_file_list:

--- a/scripts/nsidc_icesat2_associated.py
+++ b/scripts/nsidc_icesat2_associated.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 nsidc_icesat2_associated.py
-Written by Tyler Sutterley (05/2021)
+Written by Tyler Sutterley (07/2021)
 
 Acquires ICESat-2 datafiles from the National Snow and Ice Data Center (NSIDC)
     server that is associated with an input file
@@ -56,6 +56,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for syncing files
 
 UPDATE HISTORY:
+    Updated 07/2021: set context for multiprocessing to fork child processes
     Updated 05/2021: added options for connection timeout and retry attempts
     Updated 04/2021: set a default netrc file and check access
         default credentials from environmental variables
@@ -156,8 +157,10 @@ def nsidc_icesat2_associated(file_list, PRODUCT, DIRECTORY=None,
             #-- print the output string
             print('{0}\n{1}'.format(input_file,out))
     else:
+        #-- set multiprocessing start method
+        ctx = mp.get_context("fork")
         #-- download in parallel with multiprocessing Pool
-        pool = mp.Pool(processes=PROCESSES)
+        pool = ctx.Pool(processes=PROCESSES)
         #-- download each associated ICESat-2 data file
         output = []
         for i,input_file in enumerate(original_files):

--- a/scripts/nsidc_icesat2_associated.py
+++ b/scripts/nsidc_icesat2_associated.py
@@ -180,11 +180,9 @@ def nsidc_icesat2_associated(file_list, PRODUCT, DIRECTORY=None,
             print(out.get())
 
 #-- PURPOSE: wrapper for running the sync program in multiprocessing mode
-def multiprocess_sync(remote_file, remote_mtime, local_file,
-    TIMEOUT=None, RETRY=1, MODE=0o775):
+def multiprocess_sync(*args, **kwds):
     try:
-        output = http_pull_file(remote_file,remote_mtime,local_file,
-            TIMEOUT=TIMEOUT, RETRY=RETRY, MODE=MODE)
+        output = http_pull_file(*args, **kwds)
     except:
         #-- if there has been an error exception
         #-- print the type, value, and stack trace of the

--- a/scripts/nsidc_icesat2_convert.py
+++ b/scripts/nsidc_icesat2_convert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 nsidc_icesat2_convert.py
-Written by Tyler Sutterley (05/2021)
+Written by Tyler Sutterley (07/2021)
 
 Acquires ICESat-2 datafiles from NSIDC and directly converts to
     zarr datafiles or rechunked HDF5 files
@@ -83,6 +83,7 @@ PROGRAM DEPENDENCIES:
     utilities.py: download and management utilities for syncing files
 
 UPDATE HISTORY:
+    Updated 07/2021: set context for multiprocessing to fork child processes
     Updated 05/2021: added options for connection timeout and retry attempts
     Updated 04/2021: set a default netrc file and check access
         default credentials from environmental variables
@@ -264,8 +265,10 @@ def nsidc_icesat2_convert(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES, TRAC
             #-- print the output string
             print(output, file=fid) if output else None
     else:
+        #-- set multiprocessing start method
+        ctx = mp.get_context("fork")
         #-- sync in parallel with multiprocessing Pool
-        pool = mp.Pool(processes=PROCESSES)
+        pool = ctx.Pool(processes=PROCESSES)
         #-- sync each ICESat-2 data file
         out = []
         for i,remote_file in enumerate(remote_files):

--- a/scripts/nsidc_icesat2_convert.py
+++ b/scripts/nsidc_icesat2_convert.py
@@ -294,12 +294,9 @@ def nsidc_icesat2_convert(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES, TRAC
         os.chmod(os.path.join(DIRECTORY,LOGFILE), MODE)
 
 #-- PURPOSE: wrapper for running the sync program in multiprocessing mode
-def multiprocess_sync(remote_file, remote_mtime, local_file, TIMEOUT=None,
-    RETRY=1, FORMAT=None, CHUNKS=None, LIST=False, CLOBBER=False, MODE=0o775):
+def multiprocess_sync(*args, **kwds):
     try:
-        output = http_pull_file(remote_file,remote_mtime,local_file,
-            TIMEOUT=TIMEOUT, RETRY=RETRY, FORMAT=FORMAT, CHUNKS=CHUNKS,
-            LIST=LIST, CLOBBER=CLOBBER, MODE=MODE)
+        output = http_pull_file(*args, **kwds)
     except:
         #-- if there has been an error exception
         #-- print the type, value, and stack trace of the

--- a/scripts/nsidc_icesat2_sync.py
+++ b/scripts/nsidc_icesat2_sync.py
@@ -52,6 +52,7 @@ COMMAND LINE OPTIONS:
     -l, --log: output log of files downloaded
     -L, --list: print files to be transferred, but do not execute transfer
     -C, --clobber: Overwrite existing data in transfer
+    --checksum: compare hashes to check if overwriting existing data
     -M X, --mode X: Local permissions mode of the directories and files synced
 
 PYTHON DEPENDENCIES:
@@ -67,6 +68,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 07/2021: set context for multiprocessing to fork child processes
+        added option to compare checksums in order to overwrite data
     Updated 05/2021: added options for connection timeout and retry attempts
     Updated 04/2021: set a default netrc file and check access
         default credentials from environmental variables
@@ -93,6 +95,7 @@ from __future__ import print_function
 import sys
 import os
 import re
+import io
 import time
 import netrc
 import shutil
@@ -110,7 +113,7 @@ import icesat2_toolkit.utilities
 def nsidc_icesat2_sync(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES,
     TRACKS, YEARS=None, SUBDIRECTORY=None, REGION=None, AUXILIARY=False,
     INDEX=None, FLATTEN=False, TIMEOUT=None, RETRY=1, LOG=False,
-    LIST=False, PROCESSES=0, CLOBBER=False, MODE=0o775):
+    LIST=False, PROCESSES=0, CLOBBER=False, CHECKSUM=False, MODE=0o775):
 
     #-- check if directory exists and recursively create if not
     os.makedirs(DIRECTORY,MODE) if not os.path.exists(DIRECTORY) else None
@@ -253,9 +256,10 @@ def nsidc_icesat2_sync(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES,
         #-- sync each ICESat-2 data file
         for i,remote_file in enumerate(remote_files):
             #-- sync ICESat-2 files with NSIDC server
-            output = http_pull_file(remote_file, remote_mtimes[i],
-                local_files[i], TIMEOUT=TIMEOUT, RETRY=RETRY,
-                LIST=LIST, CLOBBER=CLOBBER, MODE=MODE)
+            args = (remote_file,remote_mtimes[i],local_files[i])
+            kwds = dict(TIMEOUT=TIMEOUT, RETRY=RETRY, LIST=LIST,
+                CLOBBER=CLOBBER, CHECKSUM=CHECKSUM, MODE=MODE)
+            output = http_pull_file(*args, **kwds)
             #-- print the output string
             print(output, file=fid) if output else None
     else:
@@ -269,7 +273,7 @@ def nsidc_icesat2_sync(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES,
             #-- sync ICESat-2 files with NSIDC server
             args = (remote_file,remote_mtimes[i],local_files[i])
             kwds = dict(TIMEOUT=TIMEOUT, RETRY=RETRY, LIST=LIST,
-                CLOBBER=CLOBBER, MODE=MODE)
+                CLOBBER=CLOBBER, CHECKSUM=CHECKSUM, MODE=MODE)
             out.append(pool.apply_async(multiprocess_sync,
                 args=args,kwds=kwds))
         #-- start multiprocessing jobs
@@ -289,11 +293,9 @@ def nsidc_icesat2_sync(DIRECTORY, PRODUCTS, RELEASE, VERSIONS, GRANULES,
         os.chmod(os.path.join(DIRECTORY,LOGFILE), MODE)
 
 #-- PURPOSE: wrapper for running the sync program in multiprocessing mode
-def multiprocess_sync(remote_file, remote_mtime, local_file,
-    TIMEOUT=None, RETRY=1, LIST=False, CLOBBER=False, MODE=0o775):
+def multiprocess_sync(*args, **kwds):
     try:
-        output = http_pull_file(remote_file,remote_mtime,local_file,
-            TIMEOUT=TIMEOUT,RETRY=RETRY,LIST=LIST,CLOBBER=CLOBBER,MODE=MODE)
+        output = http_pull_file(*args, **kwds)
     except:
         #-- if there has been an error exception
         #-- print the type, value, and stack trace of the
@@ -305,13 +307,34 @@ def multiprocess_sync(remote_file, remote_mtime, local_file,
 
 #-- PURPOSE: pull file from a remote host checking if file exists locally
 #-- and if the remote file is newer than the local file
-def http_pull_file(remote_file, remote_mtime, local_file,
-    TIMEOUT=None, RETRY=1, LIST=False, CLOBBER=False, MODE=0o775):
+#-- or if the checksums do not match between the files
+def http_pull_file(remote_file, remote_mtime, local_file, TIMEOUT=None,
+    RETRY=1, LIST=False, CLOBBER=False, CHECKSUM=False, MODE=0o775):
     #-- if file exists in file system: check if remote file is newer
     TEST = False
     OVERWRITE = ' (clobber)'
     #-- check if local version of file exists
-    if os.access(local_file, os.F_OK):
+        #-- check if local version of file exists
+    if CHECKSUM and os.access(local_file, os.F_OK):
+        #-- generate checksum hash for local file
+        #-- open the local_file in binary read mode
+        local_hash = icesat2_toolkit.utilities.get_hash(local_file)
+        #-- Create and submit request.
+        #-- There are a wide range of exceptions that can be thrown here
+        #-- including HTTPError and URLError.
+        request = icesat2_toolkit.utilities.urllib2.Request(remote_file)
+        response = icesat2_toolkit.utilities.urllib2.urlopen(request,
+            timeout=TIMEOUT)
+        #-- copy remote file contents to bytesIO object
+        remote_buffer = io.BytesIO(response.read())
+        remote_buffer.seek(0)
+        #-- generate checksum hash for remote file
+        remote_hash = icesat2_toolkit.utilities.get_hash(remote_buffer)
+        #-- compare checksums
+        if (local_hash != remote_hash):
+            TEST = True
+            OVERWRITE = ' (checksums: {0} {1})'.format(local_hash,remote_hash)
+    elif os.access(local_file, os.F_OK):
         #-- check last modification time of local file
         local_mtime = os.stat(local_file).st_mtime
         #-- if remote file is newer: overwrite the local file
@@ -329,35 +352,47 @@ def http_pull_file(remote_file, remote_mtime, local_file,
         if not LIST:
             #-- chunked transfer encoding size
             CHUNK = 16 * 1024
-            #-- attempt to download up to the number of retries
-            retry_counter = 0
-            while (retry_counter < RETRY):
-                #-- attempt to retrieve file from https server
-                try:
-                    #-- Create and submit request.
-                    #-- There are a range of exceptions that can be thrown here
-                    #-- including HTTPError and URLError.
-                    request=icesat2_toolkit.utilities.urllib2.Request(remote_file)
-                    response=icesat2_toolkit.utilities.urllib2.urlopen(request,
-                        timeout=TIMEOUT)
-                    #-- copy contents to file using chunked transfer encoding
-                    #-- transfer should work with ascii and binary data formats
-                    with open(local_file, 'wb') as f:
-                        shutil.copyfileobj(response, f, CHUNK)
-                except:
-                    pass
-                else:
-                    break
-                #-- add to retry counter
-                retry_counter += 1
-            #-- check if maximum number of retries were reached
-            if (retry_counter == RETRY):
-                raise TimeoutError('Maximum number of retries reached')
+            #-- copy bytes or transfer file
+            if CHECKSUM and os.access(local_file, os.F_OK):
+                #-- store bytes to file using chunked transfer encoding
+                remote_buffer.seek(0)
+                with open(local_file, 'wb') as f:
+                    shutil.copyfileobj(remote_buffer, f, CHUNK)
+            else:
+                retry_download(remote_file, local_file,
+                    TIMEOUT=TIMEOUT, RETRY=RETRY, CHUNK=CHUNK)
             #-- keep remote modification time of file and local access time
             os.utime(local_file, (os.stat(local_file).st_atime, remote_mtime))
             os.chmod(local_file, MODE)
         #-- return the output string
         return output
+
+#-- PURPOSE: Try downloading a file up to a set number of times
+def retry_download(remote_file, local_file, TIMEOUT=None, RETRY=1, CHUNK=0):
+    #-- attempt to download up to the number of retries
+    retry_counter = 0
+    while (retry_counter < RETRY):
+        #-- attempt to retrieve file from https server
+        try:
+            #-- Create and submit request.
+            #-- There are a range of exceptions that can be thrown here
+            #-- including HTTPError and URLError.
+            request=icesat2_toolkit.utilities.urllib2.Request(remote_file)
+            response=icesat2_toolkit.utilities.urllib2.urlopen(request,
+                timeout=TIMEOUT)
+            #-- copy contents to file using chunked transfer encoding
+            #-- transfer should work with ascii and binary data formats
+            with open(local_file, 'wb') as f:
+                shutil.copyfileobj(response, f, CHUNK)
+        except:
+            pass
+        else:
+            break
+        #-- add to retry counter
+        retry_counter += 1
+    #-- check if maximum number of retries were reached
+    if (retry_counter == RETRY):
+        raise TimeoutError('Maximum number of retries reached')
 
 #-- Main program that calls nsidc_icesat2_sync()
 def main():
@@ -454,6 +489,9 @@ def main():
     parser.add_argument('--clobber','-C',
         default=False, action='store_true',
         help='Overwrite existing data')
+    parser.add_argument('--checksum',
+        default=False, action='store_true',
+        help='Compare hashes to check for overwriting existing data')
     #-- permissions mode of the local directories and files (number in octal)
     parser.add_argument('--mode','-M',
         type=lambda x: int(x,base=8), default=0o775,
@@ -484,7 +522,8 @@ def main():
             SUBDIRECTORY=args.subdirectory, REGION=args.region,
             AUXILIARY=args.auxiliary, INDEX=args.index, FLATTEN=args.flatten,
             PROCESSES=args.np, TIMEOUT=args.timeout, RETRY=args.retry,
-            LOG=args.log, LIST=args.list, CLOBBER=args.clobber, MODE=args.mode)
+            LOG=args.log, LIST=args.list, CLOBBER=args.clobber,
+            CHECKSUM=args.checksum, MODE=args.mode)
 
 #-- run main program
 if __name__ == '__main__':


### PR DESCRIPTION
Hopefully fixes a bug pointed out by @mrsiegfried where child processes are not getting authentication cookies on macs (which by default use spawn)